### PR TITLE
Add support for Project API Keys (sk-proj-)

### DIFF
--- a/ui-sketcher-extension/src/ui-sketcher-token-prompt.command.ts
+++ b/ui-sketcher-extension/src/ui-sketcher-token-prompt.command.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-const OPENAI_API_TOKEN_REGEX = /^sk-\w{48}$/;
+const OPENAI_API_TOKEN_REGEX = /^(sk|sk-proj)-\w{48}$/;
 
 export class UiSketcherTokenPrompt {
   public constructor(


### PR DESCRIPTION
OpenAI recently rolled out per project API keys with the following format: 
```bash
sk-proj-abcdefghijklmnopqrstuvwxyz1234567890abcdef
```

Although this article doesn't seem to mention this specific format change you can read about it here: 
https://help.openai.com/en/articles/9186755-managing-your-work-in-the-api-platform-with-projects

You might be able to create a your own Project API key to verify here: 
https://platform.openai.com/api-keys

The current Regex pattern for API Keys only supports the classic keys
```bash
sk-abcdefghijklmnopqrstuvwxyz1234567890abcdef
```

